### PR TITLE
docs: fix link to LT-appium-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before you can start performing App automation testing with Appium, you would ne
 
 ### Clone The Sample Project
 
-Clone the LambdaTest’s [LT-appium-python](https://github.com/LambdaTest/Python-UnitTest-Selenium) and navigate to the code directory as shown below:
+Clone the LambdaTest’s [LT-appium-python](https://github.com/LambdaTest/LT-appium-python) and navigate to the code directory as shown below:
 
 ```bash
 git clone https://github.com/LambdaTest/LT-appium-python


### PR DESCRIPTION
There was a link to [Python-UnitTest-Selenium](https://github.com/LambdaTest/Python-UnitTest-Selenium) instead of [LT-appium-python](https://github.com/LambdaTest/LT-appium-python) in [README.md](https://github.com/LambdaTest/LT-appium-python/blob/f8de511171eeedc7ab17308841a13ed39b7dccc1/README.md?plain=1#L45).